### PR TITLE
Fixed not valid self-closing script tags

### DIFF
--- a/tasks/html_generator.js
+++ b/tasks/html_generator.js
@@ -105,7 +105,11 @@ module.exports = function(grunt) {
 		}
 		if (value) {
 			content += ">"+value+"</"+name+">";
-		} else {
+		}
+		else if (name === 'script'){
+		  content += "></"+name+">";
+		}
+		else {
 			content += " />";
 		}
 		return content;


### PR DESCRIPTION
Self closing `<script>` tag are not allowed in HTML5, and this yelds to a non-parseable html file (head).

Example:

```
Error: Self-closing syntax (/>) used on a non-void HTML element. Ignoring the slash and treating as a start tag.
<script type="text/javascript" src="js/lib/jquery/jquery.min.js" />
```

Tested [here](http://html5.validator.nu/). 
